### PR TITLE
[mordred] Bug with argument --from-date fixed

### DIFF
--- a/mordred/bin/mordred.sh
+++ b/mordred/bin/mordred.sh
@@ -22,10 +22,22 @@ function log_result {
 function set_variables {
     # It's replaced "-" or "." with "_" into the project name to avoid errors into MySQL
     PROJECT_SHORTNAME=`echo $PROJECT_SHORTNAME | sed "s/[-.]/_/g"`
+    if [ -z FROM_DATE ]
+        then
+        FROM_DATE_STRING=""
+        FROM_DATE=""
+    else
+        FROM_DATE_STRING=`echo $FROM_DATE | cut -d " " -f 1`
+        FROM_DATE=`echo $FROM_DATE | cut -d " " -f 2`
+    fi
 
     DB_SH=$PROJECT_SHORTNAME"_sh"
     DB_PRO=$PROJECT_SHORTNAME"_pro"
 
+    if [ -z SUPYBOT_ENRICHED_INDEX ]
+        then
+        SUPYBOT_ENRICHED_INDEX=$SUPYBOT_INDEX"_enriched"
+    fi
     if [ -z BUGZILLA_ENRICHED_INDEX ]
         then
         BUGZILLA_ENRICHED_INDEX=$BUGZILLA_INDEX"_enriched"
@@ -49,10 +61,11 @@ function set_variables {
         then
         echo "-- debugging variables --"
         echo "GIT_ENABLED=$GIT_ENABLED"
-        echo "FROM_DATE=$FROM_DATE"
+        echo "FROM_DATE=$FROM_DATE_STRING $FROM_DATE"
         echo "GERRIT_ENABLED=$GERRIT_ENABLED"
         echo "BUGZILLA_ENABLED=$BUGZILLA_ENABLED"
         echo "JENKINS_ENABLED=$JENKINS_ENABLED"
+        echo "SUPYBOT_ENABLED=$SUPYBOT_ENABLED"
         echo "PROJECT_SHORTNAME=$PROJECT_SHORTNAME"
         echo "DB_HOST=$DB_HOST"
         echo "ORGS_ENABLED=$ORGS_ENABLED"
@@ -72,6 +85,8 @@ function set_variables {
         echo "BUGZILLA_INDEX="$BUGZILLA_INDEX
         echo "JENKINS_INDEX=$JENKINS_INDEX"
         echo "JENKINS_ENRICHED_INDEX=$JENKINS_ENRICHED_INDEX"
+        echo "SUPYBOT_INDEX=$SUPYBOT_INDEX"
+        echo "SUPYBOT_ENRICHED_INDEX=$SUPYBOT_ENRICHED_INDEX"
         echo "SH_UNIFY_METHOD=$SH_UNIFY_METHOD"
         echo "SH_UNAFFILIATED_GROUP=$SH_UNAFFILIATED_GROUP"
         echo "LOGS_DIR=$LOGS_DIR"
@@ -125,6 +140,17 @@ function compose_git_list {
     log_result ". List of projects generated" ". ERROR: Error creating the Git list of projects"
 }
 
+function compose_supybot_list {
+    input_file=`echo $PROJECTS_JSON_FILE | cut -d / -f 3-`
+    cd ~/GrimoireELK/mordred/utils/
+    ./projectinfo.py $input_file list > $1
+    IFS=$'\n'
+    for project in $(cat $1);
+    do
+      ./projectinfo.py $input_file list --project_name $project --repo supybot >> $2
+    done
+}
+
 function update_projects_db {
     cd ~/VizGrimoireUtils/eclipse
     CACHED=${PROJECTS_JSON_FILE//\//_}
@@ -169,29 +195,50 @@ function retrieve_data {
         jenkins_retrieval
         log_result "[jenkins] Retrieval finished" "[jenkins] ERROR: Something went wrong with the retrieval"
     fi
+
+    if [ $SUPYBOT_ENABLED -eq 1 ]
+        then
+        log "[supybot - irc] Retrieving data"
+        supybot_retrieval
+        log_result "[supybot - irc] Retrieval finished" "[supybot - irc] ERROR: Something went wrong with the retrieval"
+    fi
 }
 
 function git_retrieval {
     TMP_GITLIST=`mktemp`
     compose_git_list $TMP_GITLIST
     cd ~/GrimoireELK/utils
-    awk -v es_uri="$ES_URI" -v myindex="$GIT_INDEX" -v myfrom="$FROM_DATE" '{print "./p2o.py -e "es_uri" --index "myindex" -g git " $3" "myfrom}' $TMP_GITLIST | sh >> $LOGS_DIR"/git-collection.log" 2>&1
+    awk -v es_uri="$ES_URI" -v myindex="$GIT_INDEX" -v myfrom="$FROM_DATE_STRING $FROM_DATE" '{print "./p2o.py -e "es_uri" --index "myindex" -g git " $3" "myfrom}' $TMP_GITLIST | sh >> $LOGS_DIR"/git-collection.log" 2>&1
     rm $TMP_GITLIST
 }
 
 function gerrit_retrieval {
-  cd ~/GrimoireELK/utils
-  ./p2o.py -e $ES_URI -g --index $GERRIT_INDEX gerrit --user $GERRIT_USER --url $GERRIT_URL $GERRIT_EXTRA_PARAM $FROM_DATE >> $LOGS_DIR"/gerrit-collection.log" 2>&1
+    cd ~/GrimoireELK/utils
+    ./p2o.py -e $ES_URI -g --index $GERRIT_INDEX gerrit --user $GERRIT_USER --url $GERRIT_URL $GERRIT_EXTRA_PARAM $FROM_DATE_STRING $FROM_DATE >> $LOGS_DIR"/gerrit-collection.log" 2>&1
 }
 
 function bugzilla_retrieval {
-  cd ~/GrimoireELK/utils
-  ./p2o.py -e $ES_URI -g --index $BUGZILLA_INDEX bugzilla -u $BUGZILLA_USER -p $BUGZILLA_PASS $BUGZILLA_URL $FROM_DATE >> $LOGS_DIR"/bugzilla-collection.log" 2>&1
+    cd ~/GrimoireELK/utils
+    ./p2o.py -e $ES_URI -g --index $BUGZILLA_INDEX bugzilla -u $BUGZILLA_USER -p $BUGZILLA_PASS $BUGZILLA_URL $FROM_DATE_STRING $FROM_DATE >> $LOGS_DIR"/bugzilla-collection.log" 2>&1
 }
 
 function jenkins_retrieval {
-  cd ~/GrimoireELK/utils
-  ./p2o.py -e $ES_URI -g --index $JENKINS_INDEX jenkins $JENKINS_URL $FROM_DATE >> $LOGS_DIR"/jenkins-collection.log" 2>&1
+    cd ~/GrimoireELK/utils
+    ./p2o.py -e $ES_URI -g --index $JENKINS_INDEX jenkins $JENKINS_URL $FROM_DATE_STRING $FROM_DATE >> $LOGS_DIR"/jenkins-collection.log" 2>&1
+}
+
+function supybot_retrieval {
+    TMP_SUPYBOT_PROJECT_LIST=`mktemp`
+    TMP_SUPYBOT_LIST=`mktemp`
+    compose_supybot_list $TMP_SUPYBOT_PROJECT_LIST $TMP_SUPYBOT_LIST
+    cd ~/GrimoireELK/utils/
+    for url in $(cat $TMP_SUPYBOT_LIST);
+    do
+        SUPYBOT_URL=`echo $url | cut -d \' -f 2`; SUPYBOT_PATH=`echo $url | cut -d \' -f 4`;
+        ./p2o.py -e $ES_URI -g --index $SUPYBOT_INDEX supybot $SUPYBOT_URL $SUPYBOT_PATH $FROM_DATE_STRING $FROM_DATE >> $LOGS_DIR"/irc-collection.log" 2>&1
+    done
+    rm $TMP_SUPYBOT_PROJECT_LIST
+    rm $TMP_SUPYBOT_LIST
 }
 
 function get_identities_from_data {
@@ -232,6 +279,13 @@ function enrich_data {
         jenkins_enrichment $1
         log_result "[jenkins] p2o finished" "[jenkins] ERROR: Something went wrong with p2o"
     fi
+
+    if [ $SUPYBOT_ENABLED -eq 1 ]
+        then
+        log "[supybot - irc] Supybot p2o starts"
+        supybot_enrichment $1
+        log_result "[supybot - irc] p2o finished" "[supybot - irc] ERROR: Something went wrong with p2o"
+    fi
 }
 
 function git_enrichment {
@@ -261,6 +315,21 @@ function jenkins_enrichment {
     ENR_EXTRA_FLAG=$1
     cd ~/GrimoireELK/utils
     ./p2o.py --db-sortinghat $DB_SH --db-projects-map $DB_PRO -e $ES_URI -g --enrich_only $ENR_EXTRA_FLAG --index $JENKINS_INDEX --index-enrich $JENKINS_ENRICHED_INDEX jenkins $JENKINS_URL >> $LOGS_DIR"/bugzilla-enrichment.log" 2>&1
+}
+
+function supybot_enrichment {
+    TMP_SUPYBOT_PROJECT_LIST=`mktemp`
+    TMP_SUPYBOT_LIST=`mktemp`
+    ENR_EXTRA_FLAG=$1
+    compose_supybot_list $TMP_SUPYBOT_PROJECT_LIST $TMP_SUPYBOT_LIST
+    cd ~/GrimoireELK/utils/
+    for url in $(cat $TMP_SUPYBOT_LIST);
+    do
+        SUPYBOT_URL=`echo $url | cut -d \' -f 2`; SUPYBOT_PATH=`echo $url | cut -d \' -f 4`;
+        ./p2o.py --db-sortinghat $DB_SH --db-projects-map $DB_PRO -e $ES_URI -g --enrich_only $ENR_EXTRA_FLAG --index $SUPYBOT_INDEX --index-enrich $SUPYBOT_ENRICHED_INDEX supybot $SUPYBOT_URL $SUPYBOT_PATH >> $LOGS_DIR"/irc-enrichment.log" 2>&1
+    done
+    rm $TMP_SUPYBOT_PROJECT_LIST
+    rm $TMP_SUPYBOT_LIST
 }
 
 function sortinghat_unify {


### PR DESCRIPTION
There is a bug with the argument "--from date" in mordred.sh.

When p2o.py is called from mordred.sh using a single variable for the
value "--from-date" and the date value (e.g.: "--from-date 2016-01-01"),
that value is interpreted wrongly by python. Python sees the value of the
variable as an unique parameter instead of two of them.

I've split the value of the variable in two parts, the string "--from-date"
and the date value.