### PR TITLE
Minor modifications to produce pypi package 0.22

### DIFF
--- a/grimoire_elk/_version.py
+++ b/grimoire_elk/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.20.rc1"
+__version__ = "0.22"

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(name="grimoire-elk",
       keywords="development repositories analytics",
       packages=['grimoire_elk', 'grimoire_elk.elk', 'grimoire_elk.ocean'],
       scripts=["utils/p2o.py"],
-      install_requires=['perceval>=0.4'],
+      install_requires=['perceval>=0.5'],
       zip_safe=False
     )


### PR DESCRIPTION
This includes a change to grimoire_elk/_version.py to push it up to 0.22, and a dependency on Perceval, specifying at least 0.5.