### PR TITLE
Add dependency on perceval-mozilla

### DIFF
--- a/grimoire_elk/_version.py
+++ b/grimoire_elk/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.22"
+__version__ = "0.22.1"

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(name="grimoire-elk",
       keywords="development repositories analytics",
       packages=['grimoire_elk', 'grimoire_elk.elk', 'grimoire_elk.ocean'],
       scripts=["utils/p2o.py"],
-      install_requires=['perceval>=0.5'],
+      install_requires=['perceval>=0.5','perceval-mozilla'],
       zip_safe=False
     )


### PR DESCRIPTION
perceval-mozilla is needed fpr p2o to run. For now, I'm including
it as a dependency. Probably we should make grimoire_elk a bit
smarter, and use perceval-mozilla only if it is available, or
else, throw an exception if it is invoked when calling the module,
but it is not installed.

I bumped version to 0.22.1 to upload a new package to pypi.