### PR TITLE
Add support for grimoire-kidash pip package.

### DIFF
--- a/README_kidash.md
+++ b/README_kidash.md
@@ -1,0 +1,8 @@
+# Kidash
+
+Kidash is a prototype of a tool for managing Kibana dashboards from the command line. It is a part of [GrimoireLab](https://grimoirelab.github.io).
+
+## Source code
+
+The source code is for now a part of [GrimoireELK](https://github.com/grimoirelab/grimoireelk).
+

--- a/setup_kidash.py
+++ b/setup_kidash.py
@@ -29,7 +29,7 @@ import re
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-readme_md = os.path.join(here, 'README.md')
+readme_md = os.path.join(here, 'README_kidash.md')
 version_py = os.path.join(here, 'grimoire_elk', '_version.py')
 
 # Pypi wants the description to be in reStrcuturedText, but
@@ -49,8 +49,8 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 
-setup(name="grimoire-elk",
-      description="GrimoireLab library to produce indexes for ElasticSearch",
+setup(name="grimoire-kidash",
+      description="GrimoireLab to manage Kibana dashboards from the command line",
       long_description=long_description,
       url="https://github.com/grimoirelab/GrimoireELK",
       version=version,
@@ -65,8 +65,10 @@ setup(name="grimoire-elk",
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4'],
       keywords="development repositories analytics",
-      packages=['grimoire_elk', 'grimoire_elk.elk', 'grimoire_elk.ocean'],
-      scripts=["utils/p2o.py"],
-      install_requires=['perceval>=0.5', 'perceval-mozilla'],
+      scripts=["utils/kidash.py"],
+      install_requires=['python-dateutil',
+            'perceval>=0.5',
+            'grimoire-elk==' + version
+            ],
       zip_safe=False
     )


### PR DESCRIPTION
Changes to allow kidash.py to be pckaged as a separate package.
This allows for easy installation of kidash.py, assuming
grimoire-elk is already installed (otherwise, it will be pulled
by dependencies in grimoire-kidash).