### PR TITLE
Change TZ so that it comes from author_date

### DIFF
--- a/grimoire_elk/elk/git.py
+++ b/grimoire_elk/elk/git.py
@@ -306,7 +306,7 @@ class GitEnrich(Enrich):
         eitem["commit_date"] = commit_date.replace(tzinfo=None).isoformat()
         eitem["utc_author"] = (author_date-author_date.utcoffset()).replace(tzinfo=None).isoformat()
         eitem["utc_commit"] = (commit_date-commit_date.utcoffset()).replace(tzinfo=None).isoformat()
-        eitem["tz"]  = int(commit_date.strftime("%z")[0:3])
+        eitem["tz"]  = int(author_date.strftime("%z")[0:3])
         # Other enrichment
         eitem["repo_name"] = item["origin"]
         # Number of files touched


### PR DESCRIPTION
In general, we're using author_date for most info.
Maybe in a later release we should include both author_tz
and commit_tz, but for now, this little change do not require
changes in panels.