### PR TITLE
Fix string to integer concatenation error.

### DIFF
--- a/grimoire_elk/ocean/gerrit.py
+++ b/grimoire_elk/ocean/gerrit.py
@@ -32,7 +32,7 @@ from .elastic import ElasticOcean
 class GerritOcean(ElasticOcean):
 
     def _fix_item(self, item):
-        item["ocean-unique-id"] = item["data"]["number"]+"_"+item['origin']
+        item["ocean-unique-id"] = str(item["data"]["number"])+"_"+item['origin']
 
     def get_elastic_mappings(self):
         # immense term in field="data.commitMessage"


### PR DESCRIPTION
got error   `unsupported operand type(s) for +: 'int' and 'str'` on gerrit ocean. fixed.