### PR TITLE
Downgrade dependency on perceval-opnfv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(name="grimoire-elk",
       keywords="development repositories analytics",
       packages=['grimoire_elk', 'grimoire_elk.elk', 'grimoire_elk.ocean'],
       scripts=["utils/p2o.py"],
-      install_requires=['perceval>=0.9.1', 'perceval-mozilla>=0.1.1', 'perceval-opnfv>=0.1.5'],
+      install_requires=['perceval>=0.9.1', 'perceval-mozilla>=0.1.1', 'perceval-opnfv>=0.1.0'],
       include_package_data=True,
       zip_safe=False
     )


### PR DESCRIPTION
The latest release of perceval-opnfv is 0.1.0, so we better have that as dependency, otherwise there is no package to satisfy it ;-)