### PR TITLE
[setup.py] Add current dependency on perceval-opnfv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(name="grimoire-elk",
       keywords="development repositories analytics",
       packages=['grimoire_elk', 'grimoire_elk.elk', 'grimoire_elk.ocean'],
       scripts=["utils/p2o.py"],
-      install_requires=['perceval>=0.9.1', 'perceval-mozilla>=0.1.1', 'perceval-opnfv>=0.1.0'],
+      install_requires=['perceval>=0.9.1', 'perceval-mozilla>=0.1.1', 'perceval-opnfv>=0.1.1'],
       include_package_data=True,
       zip_safe=False
     )


### PR DESCRIPTION
The current version of perceval-opnfv is, AFAIK, 0.1.1.