### PR TITLE
[kidash] Add support for using panels in the panels module

### DIFF
--- a/grimoire_elk/_version.py
+++ b/grimoire_elk/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.30.8"
+__version__ = "0.30.9"

--- a/kidash/README.md
+++ b/kidash/README.md
@@ -2,7 +2,41 @@
 
 Kidash is a prototype of a tool for managing Kibana dashboards from the command line. It is a part of [GrimoireLab](https://grimoirelab.github.io).
 
+## Usage
+
+Get a list of all options with:
+
+```
+$ kidash.py --help
+```
+
+For the names of the files containing panels definitions (JSON panel files),
+kidash supports both importing them from local directories, of from the
+`grimoirelab-panels` Python package, if installed. In fact, that package is
+a dependency of kidash, which means that if you installed via pip, it will
+always be present.
+
+The algorith for finding a JSON panel file is, roughly:
+
+* If the specified path (such as `panels/json/git.json` or `git.json`)
+is found relative to the local directory, use it.
+* If not found, if the specified path starts with `panels/json/`,
+remove that part and look for the panel file in the `grimoirelab-panels`
+package.
+* If not found, look for the specified path directly in the
+`grimoirelab-panels` package.
+
+For example:
+
+```
+$ kidash.py --elastic_url-enrich http://localhost:9200 \
+  --import git.json
+```
+
+will look for a file `git.json` in the current directory,
+and if not found, for `git.json` in the `grimoirelab-panels` Python package,
+if installed.
+  
 ## Source code
 
 The source code is for now a part of [GrimoireELK](https://github.com/grimoirelab/grimoireelk).
-

--- a/kidash/_version.py
+++ b/kidash/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.30.4"
+__version__ = "0.30.9"

--- a/kidash/setup.py
+++ b/kidash/setup.py
@@ -69,7 +69,8 @@ setup(name="grimoire-kidash",
       keywords="development repositories analytics",
       scripts=["kidash.py"],
       install_requires=['python-dateutil',
-        'grimoire-elk==' + version
+        'grimoire-elk>=0.30.9',
+        'panels>=0.0.1'
         ],
       include_package_data=True,
       zip_safe=False


### PR DESCRIPTION
Now, panels (JSON files with panel defintions) are looked for
first in a local directory panels/json, and if not found, in the
panels module, if it is present and importable.
For maintaining compatibility, panels with names such as
"panels/json/git.json" are supported. But the most simple
"git.json" is also supported, meaning "git.json" file in the
current directory, or "git.json" file in the corresponding
directory of the modules file.

See README.md for more details.

Versions for both grimoire-elk and grimoire-kidash are updated.

grimoirelab-panels is now a dependency of grimoire-kidash.