### PR TITLE
[jira] Add story points to enriched index, when they are available

### DIFF
--- a/grimoire_elk/elk/jira.py
+++ b/grimoire_elk/elk/jira.py
@@ -212,6 +212,11 @@ class JiraEnrich(Enrich):
         eitem['time_to_last_update_days'] = \
             get_time_diff_days(issue['fields']['created'], datetime.utcnow())
 
+        for field in issue['fields']:
+            if field.startswith('customfield_') and \
+                    (issue['fields'][field]['name'] == "Story Points"):
+                eitem['story_points'] = issue['fields'][field]['value']
+
         if self.sortinghat:
             eitem.update(self.get_item_sh(item, self.roles))
 


### PR DESCRIPTION
Story points in Jira are available when the project is created as an agile "Scrum" project, and "Story points" are ckecked in as a configuration option for the project ("Setup to use Story Points").

In this case, when the raw index is produced by Perceval, it includes stuff like:

```
        "data": {
            "key": "PTNFLY-2602",
            ...
            "fields": {
                ...
                "customfield_10005": {
                    "name": "Story Points",
                    "value": 3.0,
                    "id": "customfield_10005"
                },
        ...
            "changelog": {
                "startAt": 0,
                "total": 10,
                "histories": [
                    ...
                    {
                        "author": {

                        "items": [
                            {
                                "fieldtype": "custom",
                                "field": "Story Points",
                                "to": null,
                                "fieldId": "customfield_10005",
                                "from": null,
                                "toString": "3",
                                "fromString": null
                            }
                        ]
```

We´re getting story points from the first occurrence of them, in the list of fields. The logic is simple: check in `data['fields']` for entries with names starting with `customfield_`, which
have `Story Points` as `name` field. If found, add to the enriched item the value of the `value` field, as a number.

That's what the code in the patch does.

In some cases, the field is None, which will be translated as None in the enriched item (and then to NA when uploaded to Elasticsearch). If there is no fields with those characteristics, the code won't do anything new.

This case is useful for those projects with use Story Points, as for example Patternfly does. And my impression is that it cannot harm other cases, except for a bit of extra processing. I've tested it with the Patternfly Jira index, by recreating the enriched index from the raw index, and it seems to work.