### PR TITLE
[jira] Add code to enrich "sprint" name when SCRUM is activated.

### DIFF
--- a/grimoire_elk/elk/jira.py
+++ b/grimoire_elk/elk/jira.py
@@ -213,9 +213,14 @@ class JiraEnrich(Enrich):
             get_time_diff_days(issue['fields']['created'], datetime.utcnow())
 
         for field in issue['fields']:
-            if field.startswith('customfield_') and \
-                    (issue['fields'][field]['name'] == "Story Points"):
-                eitem['story_points'] = issue['fields'][field]['value']
+            if field.startswith('customfield_'):
+                if issue['fields'][field]['name'] == "Story Points":
+                    eitem['story_points'] = issue['fields'][field]['value']
+                elif issue['fields'][field]['name'] == "Sprint":
+                    value = issue['fields'][field]['value']
+                    if value is not None and len(value)>0:
+                        sprint = value[0].partition(",name=")[2].split(',')[0]
+                        eitem['sprint'] = sprint
 
         if self.sortinghat:
             eitem.update(self.get_item_sh(item, self.roles))


### PR DESCRIPTION
When SCRUM is activated in Jira, the sprint name comes encoded in a weird field:

```
"customfield_10007": {
                    "name": "Sprint",
                    "value": [
                        "com.atlassian.greenhopper.service.sprint.Sprint@5de0588[id=230,rapidViewId=4,state=ACTIVE,name=PatternFly Sprint 49,goal=,startDate=2017-10-24T18:25:41.062Z,endDate=2017-11-07T02:14:00.000Z,completeDate=<null>,sequence=230]"
                    ],
                    "id": "customfield_10007"
                },
```

This code extracts from this value field it the contents between ",name="  and ",", which is assumed to be the name dof the sprint, and uses it to produce a new field in the enriched index (sprint).