### PR TITLE
Remove crates empy fake repository needed by mordred

### DIFF
--- a/grimoire_elk/elk/crates.py
+++ b/grimoire_elk/elk/crates.py
@@ -63,18 +63,6 @@ class CratesEnrich(Enrich):
 
         return identities
 
-    def get_project_repository(self, eitem):
-        return str(eitem['space'])
-
-    # def get_users_data(self, item):
-    #     """ If user fields are inside the global item dict """
-    #     if 'data' in item:
-    #         users_data = item['data']['version']
-    #     else:
-    #         # the item is directly the data (kitsune answer)
-    #         users_data = item
-    #     return users_data
-
     def get_sh_identity(self, item, identity_field=None):
         identity = {}
 

--- a/grimoire_elk/ocean/crates.py
+++ b/grimoire_elk/ocean/crates.py
@@ -29,3 +29,10 @@ class CratesOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
     pass
+
+    @classmethod
+    def get_perceval_params_from_url(cls, url):
+        # crates does not need any param
+        params = []
+
+        return params


### PR DESCRIPTION
    The perceval backend for crates does not need any repository param.
    But we need to add an empty repository to projects.json so the backend
    is executed by mordred. Before creating the real perceval backend we need
    to remove this fake repository param:
    
    Contents of projects.json:
    
    {
        "grimoirelab": {
            "crates": [""]
    ...
