### PR TITLE
Fix raw mappings for bugzillarest and nntp

### DIFF
--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -165,6 +165,8 @@ class ElasticSearch(object):
                 logger.debug("Probably %i item updates" % (total-total_search))
                 break
 
+        return new_items
+
     @classmethod
     def global_mapping(cls):
         """ Return the global mapping to be used always """

--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -147,7 +147,6 @@ class ElasticSearch(object):
             res.raise_for_status()
             return res.json()['hits']['total']
 
-
         def wait_index(total_expected):
             """ Wait until ES has indexed all items """
             # Wait until in searches all items are returned
@@ -181,6 +180,7 @@ class ElasticSearch(object):
                 items_pack = []
                 if sync:
                     wait_index(total_items+max_items)
+                logger.debug('Total items already uploaded %i', total)
 
             items_pack.append(item)
 

--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -92,7 +92,8 @@ class ElasticSearch(object):
         """ Bulk PUT controlling unicode issues """
 
         try:
-            self.requests.put(url, data=bulk_json)
+            res = self.requests.put(url, data=bulk_json)
+            res.raise_for_status()
         except UnicodeEncodeError:
             # Related to body.encode('iso-8859-1'). mbox data
             logger.error("Encondig error ... converting bulk to iso-8859-1")

--- a/grimoire_elk/ocean/bugzillarest.py
+++ b/grimoire_elk/ocean/bugzillarest.py
@@ -62,6 +62,12 @@ class BugzillaRESTOcean(ElasticOcean):
                         "history": {
                             "dynamic":false,
                             "properties": {}
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
                         }
                     }
                 }

--- a/grimoire_elk/ocean/bugzillarest.py
+++ b/grimoire_elk/ocean/bugzillarest.py
@@ -23,7 +23,7 @@
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
-'''Gerrit Ocean feeder'''
+'''BugzillaREST Ocean feeder'''
 
 from .elastic import ElasticOcean
 
@@ -32,13 +32,18 @@ class BugzillaRESTOcean(ElasticOcean):
     def _fix_item(self, item):
         bug_id = str(item["data"]["id"])
         item["ocean-unique-id"] = bug_id+"_"+item['origin']
+
+        # Remove all custom fields to avoid the 1000 fields limit in ES
+        fields = list(item["data"].keys())
+        for field in fields:
+            if field.startswith("cf_"):
+                item["data"].pop(field)
         try:
             # Make this type always float (it changes between long and float)
             item["data"]['fields']["priority"]['subpriority'] = \
                 float(item["data"]['fields']["priority"]['subpriority'])
         except:
             pass
-
 
 
     def get_elastic_mappings(self):

--- a/grimoire_elk/ocean/bugzillarest.py
+++ b/grimoire_elk/ocean/bugzillarest.py
@@ -32,22 +32,35 @@ class BugzillaRESTOcean(ElasticOcean):
     def _fix_item(self, item):
         bug_id = str(item["data"]["id"])
         item["ocean-unique-id"] = bug_id+"_"+item['origin']
+        try:
+            # Make this type always float (it changes between long and float)
+            item["data"]['fields']["priority"]['subpriority'] = \
+                float(item["data"]['fields']["priority"]['subpriority'])
+        except:
+            pass
+
+
 
     def get_elastic_mappings(self):
-        # data.comments.text
+        # data.comments.text inmense term
+        # data.history.changes.removed immense term
         mapping = '''
          {
             "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "comments": {
-                                "dynamic":false,
-                                "properties": {}
-                            }
+            "properties": {
+                "data": {
+                    "properties": {
+                        "comments": {
+                            "dynamic":false,
+                            "properties": {}
+                        },
+                        "history": {
+                            "dynamic":false,
+                            "properties": {}
                         }
                     }
                 }
+            }
         }
         '''
 

--- a/grimoire_elk/ocean/nntp.py
+++ b/grimoire_elk/ocean/nntp.py
@@ -24,8 +24,9 @@
 #
 
 from .elastic import ElasticOcean
+from .mbox import MBoxOcean
 
-class NNTPOcean(ElasticOcean):
+class NNTPOcean(MBoxOcean):
     """NNTP Ocean feeder"""
 
     @classmethod

--- a/grimoire_elk/ocean/nntp.py
+++ b/grimoire_elk/ocean/nntp.py
@@ -29,6 +29,14 @@ from .mbox import MBoxOcean
 class NNTPOcean(MBoxOcean):
     """NNTP Ocean feeder"""
 
+    def _fix_item(self, item):
+        # Remove all custom fields to avoid the 1000 fields limit in ES
+        fields = list(item["data"].keys())
+        for field in fields:
+            if field.lower().startswith("x-"):
+                item["data"].pop(field)
+
+
     @classmethod
     def get_perceval_params_from_url(cls, url):
         # In the url the NNTP server and the group are included

--- a/utils/index_mapping.py
+++ b/utils/index_mapping.py
@@ -53,7 +53,7 @@ def get_params():
     parser.add_argument('--search-after', dest='search_after', action='store_true',
                         help='Use search-after for scrolling the index')
     parser.add_argument('--search-after-init', dest='search_after_value',
-                        type=int,
+                        nargs='+',
                         help='Initial value for starting the search-after')
     parser.add_argument('-c', '--copy', dest='copy', action='store_true',
                         help='Copy the indexes without modifying mappings')
@@ -223,8 +223,9 @@ def get_elastic_items_search(elastic, search_after=None, size=None):
     search_after_query = ''
 
     if search_after:
-        search_after_query = ', "search_after": [%i] ' % search_after
         logging.debug("Search after: %i", search_after)
+        # timestamp uuid
+        search_after_query = ', "search_after": [%i, "%s"] ' % (search_after[0], search_after[1])
 
     query = """
     {
@@ -235,7 +236,8 @@ def get_elastic_items_search(elastic, search_after=None, size=None):
             }
         },
         "sort": [
-            {"metadata__timestamp": "asc"}
+            {"metadata__timestamp": "asc"},
+            {"uuid": "asc"}
         ] %s
 
     }
@@ -278,7 +280,7 @@ def fetch(elastic, backend, limit=None, search_after_value=None, scroll=True):
             for hit in rjson["hits"]["hits"]:
                 item = hit['_source']
                 if 'sort' in hit:
-                    search_after = hit['sort'][0]
+                    search_after = hit['sort']
                 try:
                     backend._fix_item(item)
                 except:
@@ -298,6 +300,11 @@ def export_items(elastic_url, in_index, out_index, elastic_url_out=None,
 
     if not limit:
         limit = DEFAULT_LIMIT
+
+    if search_after_value:
+        search_after_value_timestamp = int(search_after_value[0])
+        search_after_value_uuid = search_after_value[1]
+        search_after_value = [search_after_value_timestamp, search_after_value_uuid]
 
     logging.info("Exporting items from %s/%s to %s", elastic_url, in_index, out_index)
 
@@ -332,7 +339,7 @@ def export_items(elastic_url, in_index, out_index, elastic_url_out=None,
     backend = find_perceval_backend(elastic_url, in_index)
     if search_after:
         total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit,
-                                             search_after_value, scroll=False), uid_field)
+                                                   search_after_value, scroll=False), uid_field)
     else:
         total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit), uid_field)
 

--- a/utils/index_mapping.py
+++ b/utils/index_mapping.py
@@ -319,10 +319,8 @@ def export_items(elastic_url, in_index, out_index, elastic_url_out=None,
         # Create the correct mapping for the data sources detected from in_index
         ds_mapping = find_mapping(elastic_url, in_index)
     else:
-        logging.debug('Using the remote mapping')
+        logging.debug('Using the input index mapping')
         ds_mapping = extract_mapping(elastic_url, in_index)
-
-    print(json.dumps(ds_mapping, indent=True))
 
     if not elastic_url_out:
         elastic_out = ElasticSearch(elastic_url, out_index, mappings=ds_mapping)
@@ -333,10 +331,10 @@ def export_items(elastic_url, in_index, out_index, elastic_url_out=None,
     uid_field = find_uuid(elastic_url, in_index)
     backend = find_perceval_backend(elastic_url, in_index)
     if search_after:
-        total = elastic_out.bulk_upload(fetch(elastic_in, backend, limit,
-                                        search_after_value, scroll=False), uid_field)
+        total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit,
+                                             search_after_value, scroll=False), uid_field)
     else:
-        total = elastic_out.bulk_upload(fetch(elastic_in, backend, limit), uid_field)
+        total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit), uid_field)
 
     logging.info("Total items copied: %i", total)
 

--- a/utils/index_mapping.py
+++ b/utils/index_mapping.py
@@ -223,7 +223,7 @@ def get_elastic_items_search(elastic, search_after=None, size=None):
     search_after_query = ''
 
     if search_after:
-        logging.debug("Search after: %i", search_after)
+        logging.debug("Search after: %s", search_after)
         # timestamp uuid
         search_after_query = ', "search_after": [%i, "%s"] ' % (search_after[0], search_after[1])
 


### PR DESCRIPTION
As all strings in raw indexes are stored as keywords there are some
issues with large strings that can not be stored as keywords. In
this case the string field must not be indexed.
