### PR TITLE
Bulk sync packs improvements

### DIFF
--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -165,6 +165,8 @@ class ElasticSearch(object):
                 logger.debug("Probably %i item updates" % (total-total_search))
                 break
 
+        return new_items
+
     @classmethod
     def global_mapping(cls):
         """ Return the global mapping to be used always """

--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -135,8 +135,8 @@ class ElasticSearch(object):
         return new_items
 
     def bulk_upload_sync(self, items, field_id, sync=True):
-        ''' Upload items in packs to ES using bulk API
-            and wait until the items appears in searches '''
+        """ Upload items in packs to ES using bulk API
+            and wait until the items appears in searches """
 
         # After a bulk upload the searches are not refreshed real time
         # This method waits until the upload is visible in searches
@@ -148,10 +148,11 @@ class ElasticSearch(object):
             return res.json()['hits']['total']
 
         def wait_index(total_expected):
-            """ Wait until ES has indexed all items """
-            # Wait until in searches all items are returned
-            # In incremental update, some items are updates not additions so
-            # this check will fail. Exist ok in the timeout for this case.
+            """ Wait until ES has indexed all items
+
+            In incremental update, some items are updates not additions so
+            this check will fail. Log and return with timeout in this case.
+            """
 
             total_search = 0  # total items found with search
             search_start = datetime.now()

--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -147,7 +147,6 @@ class ElasticSearch(object):
             res.raise_for_status()
             return res.json()['hits']['total']
 
-
         def wait_index(total_expected):
             """ Wait until ES has indexed all items """
             # Wait until in searches all items are returned
@@ -181,6 +180,7 @@ class ElasticSearch(object):
                 items_pack = []
                 if sync:
                     wait_index(total_items+max_items)
+                logger.debug('Total items already uploaded %i', total)
 
             items_pack.append(item)
 

--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -92,7 +92,8 @@ class ElasticSearch(object):
         """ Bulk PUT controlling unicode issues """
 
         try:
-            self.requests.put(url, data=bulk_json)
+            res = self.requests.put(url, data=bulk_json)
+            res.raise_for_status()
         except UnicodeEncodeError:
             # Related to body.encode('iso-8859-1'). mbox data
             logger.error("Encondig error ... converting bulk to iso-8859-1")


### PR DESCRIPTION
During the bulk upload in sync mode, items are now packed so after each pack, the number of items really indexed as new can be check in order to detect duplicate items or problems adding the items (for example for mappings issues).