### PR TITLE
[ocean][phabricator] Fix to float the subpriority field

### DIFF
--- a/grimoire_elk/ocean/phabricator.py
+++ b/grimoire_elk/ocean/phabricator.py
@@ -37,18 +37,27 @@ class PhabricatorOcean(ElasticOcean):
     def get_elastic_mappings(self):
         # This field data.transaction has string arrays and dicts arrays
         mapping = '''
-         {
+        {
             "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "transactions": {
-                                "dynamic":false,
-                                "properties": {}
-                            }
-                        }
-                    }
-                }
+            "properties": {
+                "data": {
+                    "properties": {
+                        "transactions": {
+                            "dynamic":false,
+                            "properties": {}
+                        },
+                        "fields": {
+                            "properties": {
+                                "priority" : {
+                                    "properties": {
+                                        "subpriority" : {"type": "float"}
+                                     }
+                                 }
+                             }
+                         }
+                     }
+                 }
+             }
         }
         '''
 


### PR DESCRIPTION
This fix the error:

   [data.fields.priority.subpriority] cannot be changed from type [long] to [float]

A float field could handle also a long field.