### PR TITLE
Enrich bugzilla rest 4611

### DIFF
--- a/grimoire_elk/elk/bugzilla.py
+++ b/grimoire_elk/elk/bugzilla.py
@@ -128,7 +128,6 @@ class BugzillaEnrich(Enrich):
         eitem['severity'] = item['data']['bug_severity'][0]['__text__']
         eitem['op_sys'] = item['data']['op_sys'][0]['__text__']
         eitem['product'] = item['data']['product'][0]['__text__']
-        eitem['project_name'] = item['data']['product'][0]['__text__']
         eitem['component'] = item['data']['component'][0]['__text__']
         eitem['platform'] = item['data']['rep_platform'][0]['__text__']
         if '__text__' in item['data']['resolution'][0]:


### PR DESCRIPTION
    [enrich][bugzillarest] Change fields to use the same names than in bugzilla
    
    In order to reuse the bugzilla panel also for bugzillarest panel
    this commit add some fields and rename others:
    
    * Added grimoire_creation_date
    * Added assignee information from Sortinghat
    * Rename summary to main_description
    * Added timeopen_days
    * Added changes field with the total number of changes for a bug

    [enrich][bugzilla] Remove project_name field to avoid confussions with dashboard projects