### PR TITLE
[enrich][sortinghat] Add identity domain using the profile information

### DIFF
--- a/grimoire_elk/elk/enrich.py
+++ b/grimoire_elk/elk/enrich.py
@@ -646,6 +646,8 @@ class Enrich(ElasticItems):
 
         if profile:
             eitem_sh[rol + "_name"] = profile['name']
+            if profile['email']:
+                eitem_sh[rol + "_domain"] = self.get_email_domain(profile['email'])
         elif not profile and sh_id:
             logger.warning("Can't find SH identity profile: %s", sh_id)
 


### PR DESCRIPTION
There was a case in which the domain was not added to the identities
field during enrichment. This fix covers it.