### PR TITLE
[mappings] If a mapping can not be created just log the issue

### DIFF
--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -31,6 +31,8 @@ import sys
 
 from time import time, sleep
 
+import requests
+
 from .utils import unixtime_to_datetime, grimoire_con
 
 
@@ -229,7 +231,10 @@ class ElasticSearch(object):
 
             # Add the global mapping shared in all data sources
             res = self.requests.put(url_map, data=self.global_mapping())
-            res.raise_for_status()
+            try:
+                res.raise_for_status()
+            except requests.exceptions.HTTPError:
+                logger.warning('Can add mapping %s: %s', url_map, self.global_mapping())
 
     def get_last_date(self, field, filters_=[]):
         '''


### PR DESCRIPTION
With old indexes (twitter for example) the old mapping are not
compatible with the current ones, and this causes a problem.

Instead of raising an exception, which will stop the process, log
a warning about the issue.