### PR TITLE
[kidash] Unbundle kidash completely

### DIFF
--- a/kidash/MANIFEST.in
+++ b/kidash/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.md
-include _version.py

--- a/kidash/bin/kidash
+++ b/kidash/bin/kidash
@@ -30,7 +30,7 @@ import sys
 
 from grimoire_elk.ocean.elastic import ElasticOcean
 from grimoire_elk.utils import config_logging
-from grimoire_elk.panels import import_dashboard, export_dashboard, list_dashboards
+from kidash.kidash import import_dashboard, export_dashboard, list_dashboards
 
 
 def get_params_parser_create_dash():

--- a/kidash/grimoire_elk
+++ b/kidash/grimoire_elk
@@ -1,1 +1,0 @@
-../grimoire_elk

--- a/kidash/kidash/__init__.py
+++ b/kidash/kidash/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Alvaro del Castillo <acs@bitergia.com>
+#
+
+import logging
+
+from ._version import __version__
+
+__all__ = [__version__]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/kidash/kidash/_version.py
+++ b/kidash/kidash/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.30.9"
+__version__ = "0.4.0"

--- a/kidash/kidash/kidash.py
+++ b/kidash/kidash/kidash.py
@@ -32,8 +32,8 @@ import os.path
 import pkgutil
 import sys
 
-from .elk.elastic import ElasticSearch
-from .elk.utils import grimoire_con
+from grimoire_elk.elk.elastic import ElasticSearch
+from grimoire_elk.elk.utils import grimoire_con
 
 logger = logging.getLogger(__name__)
 

--- a/kidash/setup.py
+++ b/kidash/setup.py
@@ -25,13 +25,14 @@
 import codecs
 import os
 import re
+import sys
 
 # Always prefer setuptools over distutils
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
-version_py = os.path.join(here, '_version.py')
+version_py = os.path.join(here, 'kidash', '_version.py')
 
 # Pypi wants the description to be in reStrcuturedText, but
 # we have it in Markdown. So, let's convert formats.
@@ -42,7 +43,7 @@ try:
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
     print("Warning: pypandoc module not found, or pandoc not installed. " +
-          "Using md instead of rst")
+          "Using md instead of rst", file=sys.stderr)
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()
 
@@ -50,7 +51,7 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 
-setup(name="grimoire-kidash",
+setup(name="kidash",
       description="GrimoireLab script to manage Kibana dashboards from the command line",
       long_description=long_description,
       url="https://github.com/grimoirelab/GrimoireELK",
@@ -67,10 +68,16 @@ setup(name="grimoire-kidash",
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5'],
       keywords="development repositories analytics",
-      scripts=["kidash.py"],
+      packages=['kidash'],
+      python_requires='>=3.4',
+      setup_requires=['wheel'],
+      extras_require={},
+      tests_require=[],
+      test_suite='tests',
+      scripts=["bin/kidash"],
       install_requires=['python-dateutil',
-                        'grimoire-elk>=0.30.9',
-                        'grimoirelab-panels>=0.0.1'
+                        'grimoire-elk>=0.30.18',
+                        'grimoirelab-panels>=0.0.7'
                         ],
       include_package_data=True,
       zip_safe=False

--- a/utils/kidash.py
+++ b/utils/kidash.py
@@ -1,1 +1,0 @@
-../kidash/kidash.py


### PR DESCRIPTION
This commit unbundles kidash completely from grimoire-elk. Now, all of kidash lives in the kidash directory, and everything should be ready to relocate in a standalone repo.

The kidash.py binary is now kidash, in the bin directory. The pip package is now kidash. Version now is 0.4.0 (it was 0.30.x with GrimoireELK, but then it was grimoire-kidash, so this is really a new package).

Please, apply this one only when grimoirelab/mordred#59 is ready to go. Ideally, accept both simultaneously, so that Mordred still works after this change.  