### PR TITLE
[ocean][confluence] Avoid creating the mapping of data.extensions.position which mutates

### DIFF
--- a/grimoire_elk/ocean/confluence.py
+++ b/grimoire_elk/ocean/confluence.py
@@ -24,9 +24,42 @@
 #
 
 from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        Non dynamic discovery of type for:
+            * data.extensions
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "extensions": {
+                                "dynamic":false,
+                                "properties": {}
+                            }
+                        }
+                    }
+                }
+        }
+        '''
+
+        return {"items": mapping}
 
 
 class ConfluenceOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
-    pass
+    mapping = Mapping


### PR DESCRIPTION
This error fixes the problem:

java.lang.IllegalArgumentException: mapper [data.extensions.position] of different type, current_type [keyword], merged_type [long]