### PR TITLE
[elastic_items] Remove empty intial filter because ES 6.x does not support it

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -145,8 +145,11 @@ class ElasticItems():
             # If using a perceval backends always filter by repository
             # to support multi repository indexes
             # We need the filter dict as a string to join with the rest
-            filters = self.get_repository_filter_raw(term=True)
-            filters = json.dumps(filters)
+            filters_dict = self.get_repository_filter_raw(term=True)
+            if filters_dict:
+                filters = json.dumps(filters_dict)
+            else:
+                filters = ''
 
             if self.filter_raw:
                 filters += '''
@@ -199,6 +202,10 @@ class ElasticItems():
                 # We need to add a bool should query to the outer must query
                 query_should = '{"bool": {%s}}' % filters_should
                 filters += ", " + query_should
+
+            # Fix the filters string if it starts with "," (empty first filter)
+            if filters.lstrip().startswith(','):
+                filters = filters.lstrip()[1:]
 
             filters_dict = json.loads("[" + filters + "]")
             if len(filters_dict) == 0:


### PR DESCRIPTION
This query which works with ES < 6.x does not work anymore:

```
{
    "query": {
        "bool": {
            "must": [
                {},
                {
                    "terms": {
                        "author_uuid": [
                            "5d9fea1ff2d686c25497d2b8010e6f9ddbb8f2a4",
                            "dae602936b2ccd72b8a62b7a428a2b94e7042d84"
                        ]
                    }
                }
            ]
        }
    }
}
```

The inicial empty term "{}," must be removed.