### PR TITLE
[ocean/confluence] Filter out body.storage.value from index

### DIFF
--- a/grimoire_elk/ocean/confluence.py
+++ b/grimoire_elk/ocean/confluence.py
@@ -49,6 +49,14 @@ class Mapping(BaseMapping):
                             "extensions": {
                                 "dynamic":false,
                                 "properties": {}
+                            },
+                            "body": {
+                                "properties": {
+                                    "storage": {
+                                        "dynamic":false,
+                                        "properties": {}
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This patch allows to filter out the indexing of the body content for confluence items. Thus, avoiding max_bytes_length_exceeded exceptions thrown by ElasticSearch when uploading data