### PR TITLE
[git] Fix for refresh identities in pair programming git

### DIFF
--- a/grimoire_elk/arthur.py
+++ b/grimoire_elk/arthur.py
@@ -570,7 +570,6 @@ def enrich_backend(url, clean, backend_name, backend_params, ocean_index=None,
 
             logger.info("Refreshing identities fields in %s", enrich_backend.elastic.index_url)
             field_id = enrich_backend.get_field_unique_id()
-            logger.info(field_id)
             eitems = refresh_identities(enrich_backend, filter_author)
             enrich_backend.elastic.bulk_upload_sync(eitems, field_id)
         else:

--- a/grimoire_elk/elk/git.py
+++ b/grimoire_elk/elk/git.py
@@ -130,24 +130,6 @@ class GitEnrich(Enrich):
         """ Field with the date in the JSON enriched items """
         return "grimoire_creation_date"
 
-    # def get_elastic_mappings(self):
-    #
-    #     fielddata = ''
-    #     if self.kibiter_version == '5':
-    #         fielddata = ', "fielddata": true'
-    #
-    #     mapping = """
-    #     {
-    #         "properties": {
-    #            "message_analyzed": {
-    #               "type": "text"
-    #               %s
-    #            }
-    #        }
-    #     }""" % fielddata
-    #
-    #     return {"items": mapping}
-
     def __get_authors(self, authors_str):
         # Extract the authors from a multiauthor
 


### PR DESCRIPTION
Fix bug when refreshing identities in pair programming git.

The uuid in this case is not unique (a raw commit could create several enriched commits with the same uuid) so a new git_uuid has been added which is unique.