### PR TITLE
[jenkins] Remove data.changeSet.items.comment from index

### DIFF
--- a/grimoire_elk/elk/elastic.py
+++ b/grimoire_elk/elk/elastic.py
@@ -156,7 +156,7 @@ class ElasticSearch(object):
             failed_items = [item['index'] for item in result['items'] if 'error' in item['index']]
             error = str(failed_items[0]['error'])
 
-            logger.error("Failed to insert data to ES: " + error)
+            logger.error("Failed to insert data to ES: %s, %s", error, url)
 
         inserted_items = len(result['items']) - len(failed_items)
 

--- a/grimoire_elk/ocean/jenkins.py
+++ b/grimoire_elk/ocean/jenkins.py
@@ -54,6 +54,18 @@ class Mapping(BaseMapping):
                             "actions": {
                                 "dynamic":false,
                                 "properties": {}
+                            },
+                            "changeSet": {
+                                "properties": {
+                                    "items": {
+                                        "properties": {
+                                            "comment": {
+                                                "type": "text",
+                                                "index": "not_analyzed"
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This fix prevents to index the comment on a changeSet. Due to some large comments on changeSets, some Jenkins items caused ElasticSearch to fail in storing them.