### PR TITLE
[travis] Add delay to make ES start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ before_install:
 # install:
 #   - ./setup.py install
 
+before_script:
+  - sleep 15
+
 script:
   - flake8 .
   - mysqladmin -u root create test_sh


### PR DESCRIPTION
This code introduces 15 second delay before the build script starts to let ElasticSearch starts. Thus it avoids the build to stall.